### PR TITLE
Expand DuckDB type support with new ParameterBinders and BatchBinders

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Add duck4s to your `build.sbt`:
 
 ```scala
 // Core library
-libraryDependencies += "com.softinio" %% "duck4s" % "0.1.3"
+libraryDependencies += "com.softinio" %% "duck4s" % "0.1.4"
 
 // Optional: cats-effect integration (includes fs2)
-libraryDependencies += "com.softinio" %% "duck4s-cats-effect" % "0.1.3"
+libraryDependencies += "com.softinio" %% "duck4s-cats-effect" % "0.1.4"
 ```
 
 #### Mill
@@ -51,13 +51,13 @@ Add duck4s to your `build.mill`:
 ```scala
 // Core library
 def ivyDeps = Agg(
-  ivy"com.softinio::duck4s::0.1.3"
+  ivy"com.softinio::duck4s::0.1.4"
 )
 
 // Optional: cats-effect integration (includes fs2)
 def ivyDeps = Agg(
-  ivy"com.softinio::duck4s::0.1.3",
-  ivy"com.softinio::duck4s-cats-effect::0.1.3"
+  ivy"com.softinio::duck4s::0.1.4",
+  ivy"com.softinio::duck4s-cats-effect::0.1.4"
 )
 ```
 

--- a/duck4s/docs/_docs/cats-effect.md
+++ b/duck4s/docs/_docs/cats-effect.md
@@ -11,14 +11,14 @@ The `duck4s-cats-effect` module provides a purely functional interface for DuckD
 ### SBT
 
 ```sbt
-libraryDependencies += "com.softinio" %% "duck4s-cats-effect" % "0.1.3"
+libraryDependencies += "com.softinio" %% "duck4s-cats-effect" % "0.1.4"
 ```
 
 ### Mill
 
 ```scala sc:nocompile
 def ivyDeps = Agg(
-  ivy"com.softinio::duck4s-cats-effect::0.1.3"
+  ivy"com.softinio::duck4s-cats-effect::0.1.4"
 )
 ```
 

--- a/duck4s/docs/_docs/getting-started.md
+++ b/duck4s/docs/_docs/getting-started.md
@@ -171,6 +171,129 @@ result match
     println(s"Batch operation failed: $error")
 ```
 
+### Supported Parameter Types
+
+Duck4s provides first-class support for all common DuckDB column types. The following types can be used with prepared statements (`setXxx` methods) and batch operations (`addBatch` tuples) without any manual conversion:
+
+| Scala / Java type | Setter method | DuckDB column type |
+|---|---|---|
+| `Int` | `setInt` | `INTEGER` |
+| `Long` | `setLong` | `BIGINT` |
+| `Double` | `setDouble` | `DOUBLE` |
+| `Float` | `setFloat` | `FLOAT` |
+| `Boolean` | `setBoolean` | `BOOLEAN` |
+| `String` | `setString` | `VARCHAR` |
+| `BigDecimal` | `setBigDecimal` | `DECIMAL` |
+| `java.sql.Date` | `setDate` | `DATE` |
+| `java.sql.Timestamp` | `setTimestamp` | `TIMESTAMP` |
+| `java.sql.Types.*` | `setNull` | any (NULL) |
+| `java.util.UUID` | `setObject` | `UUID` |
+| `java.time.LocalDate` | `setObject` | `DATE` |
+| `java.time.LocalDateTime` | `setObject` | `TIMESTAMP` |
+| `java.time.OffsetDateTime` | `setObject` | `TIMESTAMPTZ` |
+| `Array[Byte]` | `setBytes` | `BLOB` |
+| `Option[T]` | (any of the above) | nullable variant |
+
+The same types are available when reading results from a `DuckDBResultSet` via the corresponding `getXxx` methods. For BLOB columns, use `getBytes(columnLabel)` which internally wraps the DuckDB-specific `getBlob` implementation.
+
+```scala sc-compile-with:Imp.scala
+val result = DuckDBConnection.withConnection() { conn =>
+  for
+    _ <- conn.executeUpdate("""
+      CREATE TABLE events (
+        id       INTEGER,
+        name     VARCHAR,
+        score    FLOAT,
+        price    DECIMAL(10,2),
+        recorded DATE,
+        created  TIMESTAMP,
+        uid      UUID,
+        payload  BLOB
+      )
+    """)
+
+    ts    = java.sql.Timestamp.valueOf("2024-06-15 10:30:00")
+    date  = java.sql.Date.valueOf("2024-06-15")
+    uuid  = java.util.UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+    bytes = "hello".getBytes("UTF-8")
+
+    _ <- conn.withPreparedStatement("INSERT INTO events VALUES (?, ?, ?, ?, ?, ?, ?, ?)") { stmt =>
+      for
+        _ <- stmt.setInt(1, 1)
+        _ <- stmt.setString(2, "launch")
+        _ <- stmt.setFloat(3, 9.5f)
+        _ <- stmt.setBigDecimal(4, BigDecimal("19.99"))
+        _ <- stmt.setDate(5, date)
+        _ <- stmt.setTimestamp(6, ts)
+        _ <- stmt.setObject(7, uuid)
+        _ <- stmt.setBytes(8, bytes)
+        count <- stmt.executeUpdate()
+      yield count
+    }
+
+    rs <- conn.executeQuery("SELECT * FROM events WHERE id = 1")
+  yield
+    assert(rs.next())
+    val retrievedUuid  = rs.getObject("uid", classOf[java.util.UUID])
+    val retrievedBytes = rs.getBytes("payload")
+    rs.close()
+}
+```
+
+#### Batch operations with tuples
+
+`addBatch` accepts tuples of up to 6 elements, with any combination of the supported types:
+
+```scala sc-compile-with:Imp.scala
+val result = DuckDBConnection.withConnection() { conn =>
+  for
+    _ <- conn.executeUpdate("CREATE TABLE readings (id INTEGER, ts TIMESTAMP, uid UUID, val FLOAT, dec DECIMAL(10,2), data BLOB)")
+
+    batchResult <- conn.withBatch("INSERT INTO readings VALUES (?, ?, ?, ?, ?, ?)") { batch =>
+      val ts1   = java.sql.Timestamp.valueOf("2024-01-01 00:00:00")
+      val uuid1 = java.util.UUID.randomUUID()
+      for
+        _ <- batch.addBatch((1, ts1, uuid1, 1.5f, BigDecimal("9.99"), "a".getBytes("UTF-8")))
+        result <- batch.executeBatch()
+      yield result
+    }
+  yield batchResult
+}
+```
+
+#### Option support for nullable columns
+
+Wrap any supported type in `Option` to represent nullable columns — `Some(value)` binds the value and `None` inserts SQL NULL:
+
+```scala sc-compile-with:Imp.scala
+val result = DuckDBConnection.withConnection() { conn =>
+  for
+    _ <- conn.executeUpdate("CREATE TABLE contacts (id INTEGER, email VARCHAR)")
+    batchResult <- conn.withBatch("INSERT INTO contacts VALUES (?, ?)") { batch =>
+      for
+        _ <- batch.addBatch((1, Option("alice@example.com")))
+        _ <- batch.addBatch((2, Option.empty[String]))
+        r <- batch.executeBatch()
+      yield r
+    }
+  yield batchResult
+}
+```
+
+#### Custom ParameterBinder
+
+For types not covered by the built-in binders, implement the `ParameterBinder` type class:
+
+```scala sc-compile-with:Imp.scala
+import com.softinio.duck4s.algebra.{ParameterBinder, DuckDBPreparedStatement, DuckDBError}
+
+case class UserId(value: Long)
+
+given ParameterBinder[UserId] with
+  def bind(stmt: DuckDBPreparedStatement, index: Int, value: UserId): Either[DuckDBError, Unit] =
+    stmt.setLong(index, value.value).map(_ => ())
+```
+
 ### Transactions
 
 Use transactions for atomic operations:

--- a/duck4s/docs/_docs/getting-started.md
+++ b/duck4s/docs/_docs/getting-started.md
@@ -14,10 +14,10 @@ Add duck4s to your `build.sbt`:
 
 ```sbt
 // Core library
-libraryDependencies += "com.softinio" %% "duck4s" % "0.1.3"
+libraryDependencies += "com.softinio" %% "duck4s" % "0.1.4"
 
 // Optional: cats-effect integration (includes fs2)
-libraryDependencies += "com.softinio" %% "duck4s-cats-effect" % "0.1.3"
+libraryDependencies += "com.softinio" %% "duck4s-cats-effect" % "0.1.4"
 ```
 
 ### Mill
@@ -27,13 +27,13 @@ Add duck4s to your `build.mill`:
 ```scala sc:nocompile
 // Core library
 def ivyDeps = Agg(
-  ivy"com.softinio::duck4s::0.1.3"
+  ivy"com.softinio::duck4s::0.1.4"
 )
 
 // Optional: cats-effect integration (includes fs2)
 def ivyDeps = Agg(
-  ivy"com.softinio::duck4s::0.1.3",
-  ivy"com.softinio::duck4s-cats-effect::0.1.3"
+  ivy"com.softinio::duck4s::0.1.4",
+  ivy"com.softinio::duck4s-cats-effect::0.1.4"
 )
 ```
 

--- a/duck4s/src/algebra/Batch.scala
+++ b/duck4s/src/algebra/Batch.scala
@@ -298,7 +298,7 @@ object BatchBinder:
 
   /** Implicit [[BatchBinder]] for 5-element tuples.
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   given batchBinder5[A, B, C, D, E](using
       ba: ParameterBinder[A],
@@ -324,7 +324,7 @@ object BatchBinder:
 
   /** Implicit [[BatchBinder]] for 6-element tuples.
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   given batchBinder6[A, B, C, D, E, F](using
       ba: ParameterBinder[A],
@@ -523,7 +523,7 @@ object ParameterBinder:
 
   /** Implicit [[ParameterBinder]] for `Float` values.
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   given floatBinder: ParameterBinder[Float] with
     def bind(
@@ -538,7 +538,7 @@ object ParameterBinder:
     * @example
     *   {{{batch.addBatch((java.sql.Date.valueOf("2024-06-15"), "event"))}}}
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   given dateBinder: ParameterBinder[java.sql.Date] with
     def bind(
@@ -553,7 +553,7 @@ object ParameterBinder:
     * @example
     *   {{{batch.addBatch((BigDecimal("123.45"), "item"))}}}
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   given bigDecimalBinder: ParameterBinder[BigDecimal] with
     def bind(
@@ -565,7 +565,7 @@ object ParameterBinder:
 
   /** Implicit [[ParameterBinder]] for `Array[Byte]` values (BLOB columns).
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   given bytesBinder: ParameterBinder[Array[Byte]] with
     def bind(
@@ -579,7 +579,7 @@ object ParameterBinder:
     *
     * Passed via `setObject`; DuckDB maps this to the `DATE` column type.
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   given localDateBinder: ParameterBinder[java.time.LocalDate] with
     def bind(
@@ -593,7 +593,7 @@ object ParameterBinder:
     *
     * Passed via `setObject`; DuckDB maps this to the `TIMESTAMP` column type.
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   given localDateTimeBinder: ParameterBinder[java.time.LocalDateTime] with
     def bind(
@@ -607,7 +607,7 @@ object ParameterBinder:
     *
     * Passed via `setObject`; DuckDB maps this to the `TIMESTAMPTZ` column type.
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   given offsetDateTimeBinder: ParameterBinder[java.time.OffsetDateTime] with
     def bind(
@@ -622,7 +622,7 @@ object ParameterBinder:
     * @example
     *   {{{batch.addBatch((java.sql.Timestamp.valueOf("2024-01-01 12:00:00"), "event"))}}}
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   given timestampBinder: ParameterBinder[java.sql.Timestamp] with
     def bind(
@@ -640,7 +640,7 @@ object ParameterBinder:
     * @example
     *   {{{batch.addBatch((java.util.UUID.randomUUID(), "label"))}}}
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   given uuidBinder: ParameterBinder[java.util.UUID] with
     def bind(

--- a/duck4s/src/algebra/Batch.scala
+++ b/duck4s/src/algebra/Batch.scala
@@ -214,9 +214,9 @@ trait BatchBinder[T]:
 /** Companion object providing implicit [[BatchBinder]] instances for common
   * types.
   *
-  * This object contains given instances for tuples of various sizes (2, 3, and
-  * 4 elements). Each binder uses the appropriate [[ParameterBinder]] instances
-  * for the tuple elements.
+  * This object contains given instances for tuples of various sizes (2, 3, 4,
+  * 5, and 6 elements). Each binder uses the appropriate [[ParameterBinder]]
+  * instances for the tuple elements.
   *
   * @since 0.1.0
   */
@@ -294,6 +294,60 @@ object BatchBinder:
           _ <- ba.bind(stmt, 1, a)
           _ <- bb.bind(stmt, 2, b)
           _ <- bc.bind(stmt, 3, c)
+        yield ()
+
+  /** Implicit [[BatchBinder]] for 5-element tuples.
+    *
+    * @since 0.2.0
+    */
+  given batchBinder5[A, B, C, D, E](using
+      ba: ParameterBinder[A],
+      bb: ParameterBinder[B],
+      bc: ParameterBinder[C],
+      bd: ParameterBinder[D],
+      be: ParameterBinder[E]
+  ): BatchBinder[(A, B, C, D, E)] with
+    def bind(
+        stmt: DuckDBPreparedStatement,
+        values: (A, B, C, D, E)*
+    ): Either[DuckDBError, Unit] =
+      if values.isEmpty then Right(())
+      else
+        val (a, b, c, d, e) = values.head
+        for
+          _ <- ba.bind(stmt, 1, a)
+          _ <- bb.bind(stmt, 2, b)
+          _ <- bc.bind(stmt, 3, c)
+          _ <- bd.bind(stmt, 4, d)
+          _ <- be.bind(stmt, 5, e)
+        yield ()
+
+  /** Implicit [[BatchBinder]] for 6-element tuples.
+    *
+    * @since 0.2.0
+    */
+  given batchBinder6[A, B, C, D, E, F](using
+      ba: ParameterBinder[A],
+      bb: ParameterBinder[B],
+      bc: ParameterBinder[C],
+      bd: ParameterBinder[D],
+      be: ParameterBinder[E],
+      bf: ParameterBinder[F]
+  ): BatchBinder[(A, B, C, D, E, F)] with
+    def bind(
+        stmt: DuckDBPreparedStatement,
+        values: (A, B, C, D, E, F)*
+    ): Either[DuckDBError, Unit] =
+      if values.isEmpty then Right(())
+      else
+        val (a, b, c, d, e, f) = values.head
+        for
+          _ <- ba.bind(stmt, 1, a)
+          _ <- bb.bind(stmt, 2, b)
+          _ <- bc.bind(stmt, 3, c)
+          _ <- bd.bind(stmt, 4, d)
+          _ <- be.bind(stmt, 5, e)
+          _ <- bf.bind(stmt, 6, f)
         yield ()
 
   /** Implicit [[BatchBinder]] for 4-element tuples.
@@ -466,6 +520,135 @@ object ParameterBinder:
         value: Boolean
     ): Either[DuckDBError, Unit] =
       stmt.setBoolean(index, value).map(_ => ())
+
+  /** Implicit [[ParameterBinder]] for `Float` values.
+    *
+    * @since 0.2.0
+    */
+  given floatBinder: ParameterBinder[Float] with
+    def bind(
+        stmt: DuckDBPreparedStatement,
+        index: Int,
+        value: Float
+    ): Either[DuckDBError, Unit] =
+      stmt.setFloat(index, value).map(_ => ())
+
+  /** Implicit [[ParameterBinder]] for `java.sql.Date` values.
+    *
+    * @example
+    *   {{{batch.addBatch((java.sql.Date.valueOf("2024-06-15"), "event"))}}}
+    *
+    * @since 0.2.0
+    */
+  given dateBinder: ParameterBinder[java.sql.Date] with
+    def bind(
+        stmt: DuckDBPreparedStatement,
+        index: Int,
+        value: java.sql.Date
+    ): Either[DuckDBError, Unit] =
+      stmt.setDate(index, value).map(_ => ())
+
+  /** Implicit [[ParameterBinder]] for `BigDecimal` values.
+    *
+    * @example
+    *   {{{batch.addBatch((BigDecimal("123.45"), "item"))}}}
+    *
+    * @since 0.2.0
+    */
+  given bigDecimalBinder: ParameterBinder[BigDecimal] with
+    def bind(
+        stmt: DuckDBPreparedStatement,
+        index: Int,
+        value: BigDecimal
+    ): Either[DuckDBError, Unit] =
+      stmt.setBigDecimal(index, value).map(_ => ())
+
+  /** Implicit [[ParameterBinder]] for `Array[Byte]` values (BLOB columns).
+    *
+    * @since 0.2.0
+    */
+  given bytesBinder: ParameterBinder[Array[Byte]] with
+    def bind(
+        stmt: DuckDBPreparedStatement,
+        index: Int,
+        value: Array[Byte]
+    ): Either[DuckDBError, Unit] =
+      stmt.setBytes(index, value).map(_ => ())
+
+  /** Implicit [[ParameterBinder]] for `java.time.LocalDate` values.
+    *
+    * Passed via `setObject`; DuckDB maps this to the `DATE` column type.
+    *
+    * @since 0.2.0
+    */
+  given localDateBinder: ParameterBinder[java.time.LocalDate] with
+    def bind(
+        stmt: DuckDBPreparedStatement,
+        index: Int,
+        value: java.time.LocalDate
+    ): Either[DuckDBError, Unit] =
+      stmt.setObject(index, value).map(_ => ())
+
+  /** Implicit [[ParameterBinder]] for `java.time.LocalDateTime` values.
+    *
+    * Passed via `setObject`; DuckDB maps this to the `TIMESTAMP` column type.
+    *
+    * @since 0.2.0
+    */
+  given localDateTimeBinder: ParameterBinder[java.time.LocalDateTime] with
+    def bind(
+        stmt: DuckDBPreparedStatement,
+        index: Int,
+        value: java.time.LocalDateTime
+    ): Either[DuckDBError, Unit] =
+      stmt.setObject(index, value).map(_ => ())
+
+  /** Implicit [[ParameterBinder]] for `java.time.OffsetDateTime` values.
+    *
+    * Passed via `setObject`; DuckDB maps this to the `TIMESTAMPTZ` column type.
+    *
+    * @since 0.2.0
+    */
+  given offsetDateTimeBinder: ParameterBinder[java.time.OffsetDateTime] with
+    def bind(
+        stmt: DuckDBPreparedStatement,
+        index: Int,
+        value: java.time.OffsetDateTime
+    ): Either[DuckDBError, Unit] =
+      stmt.setObject(index, value).map(_ => ())
+
+  /** Implicit [[ParameterBinder]] for `java.sql.Timestamp` values.
+    *
+    * @example
+    *   {{{batch.addBatch((java.sql.Timestamp.valueOf("2024-01-01 12:00:00"), "event"))}}}
+    *
+    * @since 0.2.0
+    */
+  given timestampBinder: ParameterBinder[java.sql.Timestamp] with
+    def bind(
+        stmt: DuckDBPreparedStatement,
+        index: Int,
+        value: java.sql.Timestamp
+    ): Either[DuckDBError, Unit] =
+      stmt.setTimestamp(index, value).map(_ => ())
+
+  /** Implicit [[ParameterBinder]] for `java.util.UUID` values.
+    *
+    * DuckDB supports UUID natively; this binder uses `setObject` to pass the
+    * UUID directly without string conversion.
+    *
+    * @example
+    *   {{{batch.addBatch((java.util.UUID.randomUUID(), "label"))}}}
+    *
+    * @since 0.2.0
+    */
+  given uuidBinder: ParameterBinder[java.util.UUID] with
+    def bind(
+        stmt: DuckDBPreparedStatement,
+        index: Int,
+        value: java.util.UUID
+    ): Either[DuckDBError, Unit] =
+      stmt.setObject(index, value).map(_ => ())
 
   /** Implicit [[ParameterBinder]] for Option values.
     *

--- a/duck4s/src/algebra/PreparedStatement.scala
+++ b/duck4s/src/algebra/PreparedStatement.scala
@@ -246,8 +246,8 @@ case class DuckDBPreparedStatement(
 
   /** Sets an object parameter in the prepared statement.
     *
-    * This is primarily useful for types not covered by dedicated setter methods,
-    * such as `java.util.UUID` which DuckDB supports natively.
+    * This is primarily useful for types not covered by dedicated setter
+    * methods, such as `java.util.UUID` which DuckDB supports natively.
     *
     * @param parameterIndex
     *   the parameter index (1-based)

--- a/duck4s/src/algebra/PreparedStatement.scala
+++ b/duck4s/src/algebra/PreparedStatement.scala
@@ -213,6 +213,192 @@ case class DuckDBPreparedStatement(
           )
         )
 
+  /** Sets a timestamp parameter in the prepared statement.
+    *
+    * @param parameterIndex
+    *   the parameter index (1-based)
+    * @param value
+    *   the timestamp value to set
+    * @return
+    *   Right(value) on success, Left(DuckDBError) on failure
+    *
+    * @example
+    *   {{{stmt.setTimestamp(1, java.sql.Timestamp.valueOf("2024-01-01 12:00:00"))}}}
+    *
+    * @since 0.2.0
+    */
+  def setTimestamp(
+      parameterIndex: Int,
+      value: java.sql.Timestamp
+  ): Either[DuckDBError, java.sql.Timestamp] =
+    try
+      underlying.setTimestamp(parameterIndex, value)
+      Right(value)
+    catch
+      case e: SQLException =>
+        Left(
+          DuckDBError.QueryError(
+            s"Failed to set timestamp parameter at index $parameterIndex",
+            sql,
+            Some(e)
+          )
+        )
+
+  /** Sets an object parameter in the prepared statement.
+    *
+    * This is primarily useful for types not covered by dedicated setter methods,
+    * such as `java.util.UUID` which DuckDB supports natively.
+    *
+    * @param parameterIndex
+    *   the parameter index (1-based)
+    * @param value
+    *   the object value to set
+    * @return
+    *   Right(value) on success, Left(DuckDBError) on failure
+    *
+    * @example
+    *   {{{stmt.setObject(1, java.util.UUID.randomUUID())}}}
+    *
+    * @since 0.2.0
+    */
+  def setObject(
+      parameterIndex: Int,
+      value: AnyRef
+  ): Either[DuckDBError, AnyRef] =
+    try
+      underlying.setObject(parameterIndex, value)
+      Right(value)
+    catch
+      case e: SQLException =>
+        Left(
+          DuckDBError.QueryError(
+            s"Failed to set object parameter at index $parameterIndex",
+            sql,
+            Some(e)
+          )
+        )
+
+  /** Sets a float parameter in the prepared statement.
+    *
+    * @param parameterIndex
+    *   the parameter index (1-based)
+    * @param value
+    *   the float value to set
+    * @return
+    *   Right(value) on success, Left(DuckDBError) on failure
+    *
+    * @example
+    *   {{{stmt.setFloat(1, 3.14f)}}}
+    *
+    * @since 0.2.0
+    */
+  def setFloat(parameterIndex: Int, value: Float): Either[DuckDBError, Float] =
+    try
+      underlying.setFloat(parameterIndex, value)
+      Right(value)
+    catch
+      case e: SQLException =>
+        Left(
+          DuckDBError.QueryError(
+            s"Failed to set float parameter at index $parameterIndex",
+            sql,
+            Some(e)
+          )
+        )
+
+  /** Sets a date parameter in the prepared statement.
+    *
+    * @param parameterIndex
+    *   the parameter index (1-based)
+    * @param value
+    *   the date value to set
+    * @return
+    *   Right(value) on success, Left(DuckDBError) on failure
+    *
+    * @example
+    *   {{{stmt.setDate(1, java.sql.Date.valueOf("2024-06-15"))}}}
+    *
+    * @since 0.2.0
+    */
+  def setDate(
+      parameterIndex: Int,
+      value: java.sql.Date
+  ): Either[DuckDBError, java.sql.Date] =
+    try
+      underlying.setDate(parameterIndex, value)
+      Right(value)
+    catch
+      case e: SQLException =>
+        Left(
+          DuckDBError.QueryError(
+            s"Failed to set date parameter at index $parameterIndex",
+            sql,
+            Some(e)
+          )
+        )
+
+  /** Sets a decimal parameter in the prepared statement.
+    *
+    * @param parameterIndex
+    *   the parameter index (1-based)
+    * @param value
+    *   the BigDecimal value to set
+    * @return
+    *   Right(value) on success, Left(DuckDBError) on failure
+    *
+    * @example
+    *   {{{stmt.setBigDecimal(1, BigDecimal("123.45"))}}}
+    *
+    * @since 0.2.0
+    */
+  def setBigDecimal(
+      parameterIndex: Int,
+      value: BigDecimal
+  ): Either[DuckDBError, BigDecimal] =
+    try
+      underlying.setBigDecimal(parameterIndex, value.bigDecimal)
+      Right(value)
+    catch
+      case e: SQLException =>
+        Left(
+          DuckDBError.QueryError(
+            s"Failed to set BigDecimal parameter at index $parameterIndex",
+            sql,
+            Some(e)
+          )
+        )
+
+  /** Sets a binary parameter in the prepared statement.
+    *
+    * @param parameterIndex
+    *   the parameter index (1-based)
+    * @param value
+    *   the byte array value to set
+    * @return
+    *   Right(value) on success, Left(DuckDBError) on failure
+    *
+    * @example
+    *   {{{stmt.setBytes(1, "hello".getBytes("UTF-8"))}}}
+    *
+    * @since 0.2.0
+    */
+  def setBytes(
+      parameterIndex: Int,
+      value: Array[Byte]
+  ): Either[DuckDBError, Array[Byte]] =
+    try
+      underlying.setBytes(parameterIndex, value)
+      Right(value)
+    catch
+      case e: SQLException =>
+        Left(
+          DuckDBError.QueryError(
+            s"Failed to set bytes parameter at index $parameterIndex",
+            sql,
+            Some(e)
+          )
+        )
+
   /** Sets a parameter to NULL in the prepared statement.
     *
     * @param parameterIndex

--- a/duck4s/src/algebra/PreparedStatement.scala
+++ b/duck4s/src/algebra/PreparedStatement.scala
@@ -225,7 +225,7 @@ case class DuckDBPreparedStatement(
     * @example
     *   {{{stmt.setTimestamp(1, java.sql.Timestamp.valueOf("2024-01-01 12:00:00"))}}}
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   def setTimestamp(
       parameterIndex: Int,
@@ -259,7 +259,7 @@ case class DuckDBPreparedStatement(
     * @example
     *   {{{stmt.setObject(1, java.util.UUID.randomUUID())}}}
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   def setObject(
       parameterIndex: Int,
@@ -290,7 +290,7 @@ case class DuckDBPreparedStatement(
     * @example
     *   {{{stmt.setFloat(1, 3.14f)}}}
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   def setFloat(parameterIndex: Int, value: Float): Either[DuckDBError, Float] =
     try
@@ -318,7 +318,7 @@ case class DuckDBPreparedStatement(
     * @example
     *   {{{stmt.setDate(1, java.sql.Date.valueOf("2024-06-15"))}}}
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   def setDate(
       parameterIndex: Int,
@@ -349,7 +349,7 @@ case class DuckDBPreparedStatement(
     * @example
     *   {{{stmt.setBigDecimal(1, BigDecimal("123.45"))}}}
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   def setBigDecimal(
       parameterIndex: Int,
@@ -380,7 +380,7 @@ case class DuckDBPreparedStatement(
     * @example
     *   {{{stmt.setBytes(1, "hello".getBytes("UTF-8"))}}}
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   def setBytes(
       parameterIndex: Int,

--- a/duck4s/src/algebra/ResultSet.scala
+++ b/duck4s/src/algebra/ResultSet.scala
@@ -95,7 +95,7 @@ case class DuckDBResultSet(
     * DuckDB JDBC does not implement the standard `getBytes` method; this wraps
     * `getBlob` internally.
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   def getBytes(columnLabel: String): Array[Byte] =
     val blob = underlying.getBlob(columnLabel)
@@ -110,7 +110,7 @@ case class DuckDBResultSet(
     * DuckDB JDBC does not implement the standard `getBytes` method; this wraps
     * `getBlob` internally.
     *
-    * @since 0.2.0
+    * @since 0.1.4
     */
   def getBytes(columnIndex: Int): Array[Byte] =
     val blob = underlying.getBlob(columnIndex)

--- a/duck4s/src/algebra/ResultSet.scala
+++ b/duck4s/src/algebra/ResultSet.scala
@@ -92,8 +92,8 @@ case class DuckDBResultSet(
 
   /** Returns the raw bytes of a BLOB column, or null if SQL NULL.
     *
-    * DuckDB JDBC does not implement the standard `getBytes` method; this
-    * wraps `getBlob` internally.
+    * DuckDB JDBC does not implement the standard `getBytes` method; this wraps
+    * `getBlob` internally.
     *
     * @since 0.2.0
     */
@@ -107,8 +107,8 @@ case class DuckDBResultSet(
 
   /** Returns the raw bytes of a BLOB column, or null if SQL NULL.
     *
-    * DuckDB JDBC does not implement the standard `getBytes` method; this
-    * wraps `getBlob` internally.
+    * DuckDB JDBC does not implement the standard `getBytes` method; this wraps
+    * `getBlob` internally.
     *
     * @since 0.2.0
     */

--- a/duck4s/src/algebra/ResultSet.scala
+++ b/duck4s/src/algebra/ResultSet.scala
@@ -63,8 +63,14 @@ case class DuckDBResultSet(
     *   - `getInt(columnIndex/columnLabel)`: Get integer value
     *   - `getLong(columnIndex/columnLabel)`: Get long value
     *   - `getDouble(columnIndex/columnLabel)`: Get double value
+    *   - `getFloat(columnIndex/columnLabel)`: Get float value
     *   - `getBoolean(columnIndex/columnLabel)`: Get boolean value
     *   - `wasNull()`: Check if last retrieved value was NULL
+    *   - `getDate(columnIndex/columnLabel)`: Get date value
+    *   - `getTimestamp(columnIndex/columnLabel)`: Get timestamp value
+    *   - `getBigDecimal(columnIndex/columnLabel)`: Get decimal value
+    *   - `getArray(columnIndex/columnLabel)`: Get array value
+    *   - `getObject(columnIndex/columnLabel)`: Get object value
     *
     * @since 0.1.0
     */
@@ -74,9 +80,45 @@ case class DuckDBResultSet(
     getInt,
     getLong,
     getDouble,
+    getFloat,
     getBoolean,
-    wasNull
+    wasNull,
+    getTimestamp,
+    getDate,
+    getBigDecimal,
+    getArray,
+    getObject
   }
+
+  /** Returns the raw bytes of a BLOB column, or null if SQL NULL.
+    *
+    * DuckDB JDBC does not implement the standard `getBytes` method; this
+    * wraps `getBlob` internally.
+    *
+    * @since 0.2.0
+    */
+  def getBytes(columnLabel: String): Array[Byte] =
+    val blob = underlying.getBlob(columnLabel)
+    if blob == null then null
+    else
+      val bytes = blob.getBytes(1L, blob.length().toInt)
+      blob.free()
+      bytes
+
+  /** Returns the raw bytes of a BLOB column, or null if SQL NULL.
+    *
+    * DuckDB JDBC does not implement the standard `getBytes` method; this
+    * wraps `getBlob` internally.
+    *
+    * @since 0.2.0
+    */
+  def getBytes(columnIndex: Int): Array[Byte] =
+    val blob = underlying.getBlob(columnIndex)
+    if blob == null then null
+    else
+      val bytes = blob.getBytes(1L, blob.length().toInt)
+      blob.free()
+      bytes
 
   /** Closes both the underlying ResultSet and its associated Statement.
     *

--- a/duck4s/test/src/algebra/BatchTest.scala
+++ b/duck4s/test/src/algebra/BatchTest.scala
@@ -259,6 +259,125 @@ class BatchTest extends munit.FunSuite:
 
     assert(result.isRight)
 
+  test("batch insert - float, date, BigDecimal, bytes"):
+    val result = DuckDBConnection.withConnection(): conn =>
+      for
+        _ <- conn.executeUpdate(
+          """CREATE TABLE batch_types2 (
+            |  id INTEGER,
+            |  f FLOAT,
+            |  d DATE,
+            |  dec DECIMAL(10,2),
+            |  b BLOB
+            |)""".stripMargin
+        )
+        date  = java.sql.Date.valueOf("2024-06-15")
+        price = BigDecimal("99.99")
+        bytes = "duck4s".getBytes("UTF-8")
+
+        batchResult <- conn.withBatch(
+          "INSERT INTO batch_types2 VALUES (?, ?, ?, ?, ?)"
+        ): batch =>
+          for
+            _ <- batch.addBatch((1, 1.5f, date, price, bytes))
+            result <- batch.executeBatch()
+          yield result
+
+        rs <- conn.executeQuery("SELECT * FROM batch_types2 WHERE id = 1")
+      yield
+        assertEquals(batchResult.successCount, 1)
+        assert(rs.next())
+        assertEquals(rs.getFloat("f"), 1.5f)
+        assertEquals(rs.getDate("d"), date)
+        assertEquals(BigDecimal(rs.getBigDecimal("dec")), price)
+        assertEquals(rs.getBytes("b").toList, bytes.toList)
+        rs.close()
+
+    assert(result.isRight)
+
+  test("batch insert - java.time binders"):
+    val result = DuckDBConnection.withConnection(): conn =>
+      for
+        _ <- conn.executeUpdate(
+          """CREATE TABLE batch_jtime (
+            |  id INTEGER,
+            |  ld DATE,
+            |  ldt TIMESTAMP,
+            |  odt TIMESTAMPTZ
+            |)""".stripMargin
+        )
+        localDate     = java.time.LocalDate.of(2024, 3, 1)
+        localDateTime = java.time.LocalDateTime.of(2024, 3, 1, 9, 0, 0)
+        offsetDateTime = java.time.OffsetDateTime.of(
+          localDateTime,
+          java.time.ZoneOffset.UTC
+        )
+
+        batchResult <- conn.withBatch(
+          "INSERT INTO batch_jtime VALUES (?, ?, ?, ?)"
+        ): batch =>
+          for
+            _ <- batch.addBatch((1, localDate, localDateTime, offsetDateTime))
+            result <- batch.executeBatch()
+          yield result
+
+        rs <- conn.executeQuery("SELECT * FROM batch_jtime WHERE id = 1")
+      yield
+        assertEquals(batchResult.successCount, 1)
+        assert(rs.next())
+        assertEquals(
+          rs.getObject("ld", classOf[java.time.LocalDate]),
+          localDate
+        )
+        assertEquals(
+          rs.getObject("ldt", classOf[java.time.LocalDateTime]),
+          localDateTime
+        )
+        rs.close()
+
+    assert(result.isRight)
+
+  test("batch insert - with Timestamp and UUID"):
+    val result = DuckDBConnection.withConnection(): conn =>
+      for
+        _ <- conn.executeUpdate(
+          "CREATE TABLE batch_ts_uuid (id INTEGER, ts TIMESTAMP, uid UUID)"
+        )
+        ts1 = java.sql.Timestamp.valueOf("2024-01-01 00:00:00")
+        ts2 = java.sql.Timestamp.valueOf("2024-06-15 12:30:00")
+        uuid1 = java.util.UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+        uuid2 = java.util.UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+        batchResult <- conn.withBatch(
+          "INSERT INTO batch_ts_uuid VALUES (?, ?, ?)"
+        ): batch =>
+          for
+            _ <- batch.addBatch((1, ts1, uuid1))
+            _ <- batch.addBatch((2, ts2, uuid2))
+            result <- batch.executeBatch()
+          yield result
+
+        rs <- conn.executeQuery(
+          "SELECT * FROM batch_ts_uuid ORDER BY id"
+        )
+      yield
+        assertEquals(batchResult.successCount, 2)
+
+        assert(rs.next())
+        assertEquals(rs.getInt("id"), 1)
+        assertEquals(rs.getTimestamp("ts"), ts1)
+        assertEquals(rs.getObject("uid", classOf[java.util.UUID]), uuid1)
+
+        assert(rs.next())
+        assertEquals(rs.getInt("id"), 2)
+        assertEquals(rs.getTimestamp("ts"), ts2)
+        assertEquals(rs.getObject("uid", classOf[java.util.UUID]), uuid2)
+
+        assert(!rs.next())
+        rs.close()
+
+    assert(result.isRight)
+
   test("batch insert - transaction with batch"):
     val result = DuckDBConnection.withConnection(): conn =>
       for

--- a/duck4s/test/src/algebra/BatchTest.scala
+++ b/duck4s/test/src/algebra/BatchTest.scala
@@ -271,7 +271,7 @@ class BatchTest extends munit.FunSuite:
             |  b BLOB
             |)""".stripMargin
         )
-        date  = java.sql.Date.valueOf("2024-06-15")
+        date = java.sql.Date.valueOf("2024-06-15")
         price = BigDecimal("99.99")
         bytes = "duck4s".getBytes("UTF-8")
 
@@ -306,7 +306,7 @@ class BatchTest extends munit.FunSuite:
             |  odt TIMESTAMPTZ
             |)""".stripMargin
         )
-        localDate     = java.time.LocalDate.of(2024, 3, 1)
+        localDate = java.time.LocalDate.of(2024, 3, 1)
         localDateTime = java.time.LocalDateTime.of(2024, 3, 1, 9, 0, 0)
         offsetDateTime = java.time.OffsetDateTime.of(
           localDateTime,
@@ -345,8 +345,12 @@ class BatchTest extends munit.FunSuite:
         )
         ts1 = java.sql.Timestamp.valueOf("2024-01-01 00:00:00")
         ts2 = java.sql.Timestamp.valueOf("2024-06-15 12:30:00")
-        uuid1 = java.util.UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
-        uuid2 = java.util.UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+        uuid1 = java.util.UUID.fromString(
+          "550e8400-e29b-41d4-a716-446655440000"
+        )
+        uuid2 = java.util.UUID.fromString(
+          "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        )
 
         batchResult <- conn.withBatch(
           "INSERT INTO batch_ts_uuid VALUES (?, ?, ?)"

--- a/duck4s/test/src/algebra/PreparedStatementTest.scala
+++ b/duck4s/test/src/algebra/PreparedStatementTest.scala
@@ -189,6 +189,192 @@ class PreparedStatementTest extends munit.FunSuite:
         assert(message.nonEmpty)
       case _ => fail("Expected QueryError")
 
+  test("prepared statement - timestamp parameter"):
+    val result = DuckDBConnection.withConnection(): conn =>
+      for
+        _ <- conn.executeUpdate(
+          "CREATE TABLE ps_timestamp (id INTEGER, created_at TIMESTAMP)"
+        )
+        ts = java.sql.Timestamp.valueOf("2024-06-15 10:30:00")
+
+        insertResult <- conn.withPreparedStatement(
+          "INSERT INTO ps_timestamp VALUES (?, ?)"
+        ): stmt =>
+          for
+            _ <- stmt.setInt(1, 1)
+            _ <- stmt.setTimestamp(2, ts)
+            count <- stmt.executeUpdate()
+          yield count
+
+        rs <- conn.executeQuery("SELECT * FROM ps_timestamp WHERE id = 1")
+      yield
+        assertEquals(insertResult, 1)
+        assert(rs.next())
+        assertEquals(rs.getInt("id"), 1)
+        assertEquals(rs.getTimestamp("created_at"), ts)
+        rs.close()
+
+    assert(result.isRight)
+
+  test("prepared statement - uuid parameter"):
+    val result = DuckDBConnection.withConnection(): conn =>
+      for
+        _ <- conn.executeUpdate(
+          "CREATE TABLE ps_uuid (id INTEGER, uid UUID)"
+        )
+        uuid = java.util.UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+
+        insertResult <- conn.withPreparedStatement(
+          "INSERT INTO ps_uuid VALUES (?, ?)"
+        ): stmt =>
+          for
+            _ <- stmt.setInt(1, 1)
+            _ <- stmt.setObject(2, uuid)
+            count <- stmt.executeUpdate()
+          yield count
+
+        rs <- conn.executeQuery("SELECT * FROM ps_uuid WHERE id = 1")
+      yield
+        assertEquals(insertResult, 1)
+        assert(rs.next())
+        assertEquals(rs.getInt("id"), 1)
+        assertEquals(rs.getObject("uid", classOf[java.util.UUID]), uuid)
+        rs.close()
+
+    assert(result.isRight)
+
+  test("prepared statement - float parameter"):
+    val result = DuckDBConnection.withConnection(): conn =>
+      for
+        _ <- conn.executeUpdate("CREATE TABLE ps_float (id INTEGER, val FLOAT)")
+        insertResult <- conn.withPreparedStatement(
+          "INSERT INTO ps_float VALUES (?, ?)"
+        ): stmt =>
+          for
+            _ <- stmt.setInt(1, 1)
+            _ <- stmt.setFloat(2, 3.14f)
+            count <- stmt.executeUpdate()
+          yield count
+        rs <- conn.executeQuery("SELECT * FROM ps_float WHERE id = 1")
+      yield
+        assertEquals(insertResult, 1)
+        assert(rs.next())
+        assertEquals(rs.getFloat("val"), 3.14f)
+        rs.close()
+
+    assert(result.isRight)
+
+  test("prepared statement - date parameter"):
+    val result = DuckDBConnection.withConnection(): conn =>
+      for
+        _ <- conn.executeUpdate("CREATE TABLE ps_date (id INTEGER, d DATE)")
+        date = java.sql.Date.valueOf("2024-06-15")
+        insertResult <- conn.withPreparedStatement(
+          "INSERT INTO ps_date VALUES (?, ?)"
+        ): stmt =>
+          for
+            _ <- stmt.setInt(1, 1)
+            _ <- stmt.setDate(2, date)
+            count <- stmt.executeUpdate()
+          yield count
+        rs <- conn.executeQuery("SELECT * FROM ps_date WHERE id = 1")
+      yield
+        assertEquals(insertResult, 1)
+        assert(rs.next())
+        assertEquals(rs.getDate("d"), date)
+        rs.close()
+
+    assert(result.isRight)
+
+  test("prepared statement - BigDecimal parameter"):
+    val result = DuckDBConnection.withConnection(): conn =>
+      for
+        _ <- conn.executeUpdate(
+          "CREATE TABLE ps_decimal (id INTEGER, price DECIMAL(10,2))"
+        )
+        price = BigDecimal("123.45")
+        insertResult <- conn.withPreparedStatement(
+          "INSERT INTO ps_decimal VALUES (?, ?)"
+        ): stmt =>
+          for
+            _ <- stmt.setInt(1, 1)
+            _ <- stmt.setBigDecimal(2, price)
+            count <- stmt.executeUpdate()
+          yield count
+        rs <- conn.executeQuery("SELECT * FROM ps_decimal WHERE id = 1")
+      yield
+        assertEquals(insertResult, 1)
+        assert(rs.next())
+        assertEquals(BigDecimal(rs.getBigDecimal("price")), price)
+        rs.close()
+
+    assert(result.isRight)
+
+  test("prepared statement - bytes parameter (BLOB)"):
+    val result = DuckDBConnection.withConnection(): conn =>
+      for
+        _ <- conn.executeUpdate("CREATE TABLE ps_blob (id INTEGER, data BLOB)")
+        bytes = "hello duck4s".getBytes("UTF-8")
+        insertResult <- conn.withPreparedStatement(
+          "INSERT INTO ps_blob VALUES (?, ?)"
+        ): stmt =>
+          for
+            _ <- stmt.setInt(1, 1)
+            _ <- stmt.setBytes(2, bytes)
+            count <- stmt.executeUpdate()
+          yield count
+        rs <- conn.executeQuery("SELECT * FROM ps_blob WHERE id = 1")
+      yield
+        assertEquals(insertResult, 1)
+        assert(rs.next())
+        assertEquals(rs.getBytes("data").toList, bytes.toList)
+        rs.close()
+
+    assert(result.isRight)
+
+  test("prepared statement - java.time types"):
+    val result = DuckDBConnection.withConnection(): conn =>
+      for
+        _ <- conn.executeUpdate(
+          """CREATE TABLE ps_jtime (
+            |  id INTEGER,
+            |  ld DATE,
+            |  ldt TIMESTAMP,
+            |  odt TIMESTAMPTZ
+            |)""".stripMargin
+        )
+        localDate     = java.time.LocalDate.of(2024, 6, 15)
+        localDateTime = java.time.LocalDateTime.of(2024, 6, 15, 10, 30, 0)
+        offsetDateTime = java.time.OffsetDateTime.of(
+          localDateTime,
+          java.time.ZoneOffset.UTC
+        )
+        insertResult <- conn.withPreparedStatement(
+          "INSERT INTO ps_jtime VALUES (?, ?, ?, ?)"
+        ): stmt =>
+          for
+            _ <- stmt.setInt(1, 1)
+            _ <- stmt.setObject(2, localDate)
+            _ <- stmt.setObject(3, localDateTime)
+            _ <- stmt.setObject(4, offsetDateTime)
+            count <- stmt.executeUpdate()
+          yield count
+        rs <- conn.executeQuery("SELECT * FROM ps_jtime WHERE id = 1")
+      yield
+        assertEquals(insertResult, 1)
+        assert(rs.next())
+        assertEquals(
+          rs.getObject("ld", classOf[java.time.LocalDate]),
+          localDate
+        )
+        assertEquals(
+          rs.getObject("ldt", classOf[java.time.LocalDateTime]),
+          localDateTime
+        )
+        rs.close()
+
+    assert(result.isRight)
+
   test("prepared statement - sql injection protection"):
     val result = DuckDBConnection.withConnection(): conn =>
       for

--- a/duck4s/test/src/algebra/PreparedStatementTest.scala
+++ b/duck4s/test/src/algebra/PreparedStatementTest.scala
@@ -343,7 +343,7 @@ class PreparedStatementTest extends munit.FunSuite:
             |  odt TIMESTAMPTZ
             |)""".stripMargin
         )
-        localDate     = java.time.LocalDate.of(2024, 6, 15)
+        localDate = java.time.LocalDate.of(2024, 6, 15)
         localDateTime = java.time.LocalDateTime.of(2024, 6, 15, 10, 30, 0)
         offsetDateTime = java.time.OffsetDateTime.of(
           localDateTime,

--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "lastModified": 1772773019,
+        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
         "type": "github"
       },
       "original": {

--- a/scripts/example-cats-effect-usage.scala
+++ b/scripts/example-cats-effect-usage.scala
@@ -2,8 +2,8 @@
 // This script demonstrates basic usage of the duck4s-cats-effect library after publishing locally
 //> using scala "3.8.2"
 //> using repository "ivy2Local"
-//> using dep "com.softinio:duck4s_3:0.1.2-4-1bed287"              // Update this version to match your locally published version
-//> using dep "com.softinio:duck4s-cats-effect_3:0.1.2-4-1bed287" // Update this version to match your locally published version
+//> using dep "com.softinio:duck4s_3:0.1.3-5-104ede9"              // Update this version to match your locally published version
+//> using dep "com.softinio:duck4s-cats-effect_3:0.1.3-5-104ede9" // Update this version to match your locally published version
 
 import cats.effect.{IO, IOApp}
 import com.softinio.duck4s.effect.*
@@ -17,6 +17,8 @@ object TestDuck4sCatsEffect extends IOApp.Simple:
       testStream >>
       testTransaction >>
       testRollback >>
+      testNewTypes >>
+      testBatchNewTypes >>
       IO.println("\nAll tests passed!")
 
   def testConnection: IO[Unit] =
@@ -82,6 +84,74 @@ object TestDuck4sCatsEffect extends IOApp.Simple:
           assert(rs.getInt(1) == 0, "expected 0 rows after rollback")
           rs.close()
         _ <- IO.println("withTransactionIO rolls back on error OK")
+      yield ()
+    }
+
+  // New in 0.1.4: setFloat, setDate, setTimestamp, setObject (UUID),
+  // setBigDecimal, setBytes; and ResultSet.getBytes
+  def testNewTypes: IO[Unit] =
+    DuckDBIO.connect().use { conn =>
+      val ts    = java.sql.Timestamp.valueOf("2024-06-15 10:30:00")
+      val date  = java.sql.Date.valueOf("2024-06-15")
+      val uuid  = java.util.UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+      val bytes = "hello".getBytes("UTF-8")
+
+      for
+        _ <- conn.executeUpdateIO("""
+          CREATE TABLE events (
+            id       INTEGER,
+            score    FLOAT,
+            price    DECIMAL(10,2),
+            recorded DATE,
+            created  TIMESTAMP,
+            uid      UUID,
+            payload  BLOB
+          )
+        """)
+        _ <- conn.withPreparedStatementIO("INSERT INTO events VALUES (?, ?, ?, ?, ?, ?, ?)") { stmt =>
+          for
+            _ <- IO.blocking(stmt.setInt(1, 1))
+            _ <- IO.blocking(stmt.setFloat(2, 9.5f))
+            _ <- IO.blocking(stmt.setBigDecimal(3, BigDecimal("19.99")))
+            _ <- IO.blocking(stmt.setDate(4, date))
+            _ <- IO.blocking(stmt.setTimestamp(5, ts))
+            _ <- IO.blocking(stmt.setObject(6, uuid))
+            _ <- IO.blocking(stmt.setBytes(7, bytes))
+            n <- IO.blocking(stmt.executeUpdate())
+          yield n
+        }
+        rs <- conn.executeQueryIO("SELECT * FROM events WHERE id = 1")
+        _ <- IO:
+          assert(rs.next(), "expected a row")
+          assert(rs.getFloat("score") == 9.5f)
+          val blob = rs.getBytes("payload")
+          assert(new String(blob) == "hello", s"expected 'hello' blob, got '${new String(blob)}'")
+          rs.close()
+        _ <- IO.println("0.1.4 new PreparedStatement types (setFloat/setDate/setTimestamp/setObject/setBigDecimal/setBytes) and ResultSet.getBytes OK")
+      yield ()
+    }
+
+  // New in 0.1.4: batch binders for Float, BigDecimal, UUID, Date, Timestamp, Blob
+  def testBatchNewTypes: IO[Unit] =
+    DuckDBIO.connect().use { conn =>
+      val ts    = java.sql.Timestamp.valueOf("2024-01-01 00:00:00")
+      val date  = java.sql.Date.valueOf("2024-01-01")
+      val uuid  = java.util.UUID.randomUUID()
+      val bytes = "data".getBytes("UTF-8")
+
+      for
+        _ <- conn.executeUpdateIO("CREATE TABLE readings (id INTEGER, ts TIMESTAMP, uid UUID, val FLOAT, dec DECIMAL(10,2), data BLOB)")
+        result <- conn.withBatchIO("INSERT INTO readings VALUES (?, ?, ?, ?, ?, ?)") { batch =>
+          for
+            _ <- IO.blocking(batch.addBatch((1, ts, uuid, 1.5f, BigDecimal("9.99"), bytes)))
+            r <- IO.blocking(batch.executeBatch()).flatMap {
+              case Right(r) => IO.pure(r)
+              case Left(e)  => IO.raiseError(new RuntimeException(e.toString))
+            }
+          yield r
+        }
+        _ <- IO(assert(result.successCount == 1, s"expected 1 success, got ${result.successCount}"))
+        _ <- IO.println(s"0.1.4 batch with new types OK: ${result.successCount} inserted")
       yield ()
     }
 

--- a/scripts/example-usage.scala
+++ b/scripts/example-usage.scala
@@ -2,7 +2,7 @@
 // This script demonstrates basic usage of the duck4s library after publishing locally
 //> using scala "3.8.2"
 //> using repository "ivy2Local"
-//> using dep "com.softinio:duck4s_3:0.1.2-4-1bed287" // Update this version to match your locally published version
+//> using dep "com.softinio:duck4s_3:0.1.3-5-104ede9" // Update this version to match your locally published version
 
 import com.softinio.duck4s.*
 import com.softinio.duck4s.algebra.*
@@ -44,13 +44,86 @@ import com.softinio.duck4s.algebra.*
       }
     }
   } match {
-    case Right(_) => println("✅ Query completed")
+    case Right(_) => println("✅ Basic query completed")
     case Left(error) => println(s"❌ Query failed: $error")
+  }
+
+  // Test new 0.1.4 PreparedStatement features: setFloat, setDate, setTimestamp,
+  // setObject (UUID), setBigDecimal, setBytes; and ResultSet.getBytes
+  println("\nTesting 0.1.4 new type support...")
+
+  connection.executeUpdate("""
+    CREATE TABLE events (
+      id        INTEGER,
+      score     FLOAT,
+      price     DECIMAL(10,2),
+      recorded  DATE,
+      created   TIMESTAMP,
+      uid       UUID,
+      payload   BLOB
+    )
+  """) match {
+    case Right(_) => println("✅ Created events table")
+    case Left(error) => println(s"❌ Failed to create events table: $error")
+  }
+
+  val ts    = java.sql.Timestamp.valueOf("2024-06-15 10:30:00")
+  val date  = java.sql.Date.valueOf("2024-06-15")
+  val uuid  = java.util.UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+  val bytes = "hello".getBytes("UTF-8")
+
+  connection.withPreparedStatement("INSERT INTO events VALUES (?, ?, ?, ?, ?, ?, ?)") { stmt =>
+    for
+      _ <- stmt.setInt(1, 1)
+      _ <- stmt.setFloat(2, 9.5f)
+      _ <- stmt.setBigDecimal(3, BigDecimal("19.99"))
+      _ <- stmt.setDate(4, date)
+      _ <- stmt.setTimestamp(5, ts)
+      _ <- stmt.setObject(6, uuid)
+      _ <- stmt.setBytes(7, bytes)
+      count <- stmt.executeUpdate()
+    yield count
+  } match {
+    case Right(n) => println(s"✅ Inserted $n row with new types")
+    case Left(error) => println(s"❌ Insert with new types failed: $error")
+  }
+
+  connection.executeQuery("SELECT * FROM events WHERE id = 1") match {
+    case Right(rs) =>
+      if rs.next() then
+        val score   = rs.getFloat("score")
+        val price   = rs.getBigDecimal("price")
+        val rec     = rs.getDate("recorded")
+        val created = rs.getTimestamp("created")
+        val uid     = rs.getObject("uid", classOf[java.util.UUID])
+        val blob    = rs.getBytes("payload")
+        println(s"  score=$score price=$price recorded=$rec created=$created uid=$uid payload=${new String(blob)}")
+        println("✅ Read back all new types successfully")
+      rs.close()
+    case Left(error) => println(s"❌ Query for new types failed: $error")
+  }
+
+  // Test batch with new types (Float, BigDecimal, UUID, Date, Timestamp) - max 6-element tuple
+  println("\nTesting 0.1.4 batch with new types...")
+
+  connection.executeUpdate("CREATE TABLE readings (id INTEGER, val FLOAT, dec DECIMAL(10,2), uid UUID, dt DATE, ts TIMESTAMP)") match {
+    case Right(_) => ()
+    case Left(error) => println(s"❌ Failed to create readings table: $error")
+  }
+
+  connection.withBatch("INSERT INTO readings VALUES (?, ?, ?, ?, ?, ?)") { batch =>
+    for
+      _ <- batch.addBatch((1, 7.5f, BigDecimal("9.99"), uuid, date, ts))
+      result <- batch.executeBatch()
+    yield result
+  } match {
+    case Right(r) => println(s"✅ Batch with new types: ${r.successCount} inserted, ${r.failureCount} failed")
+    case Left(error) => println(s"❌ Batch with new types failed: $error")
   }
 
   // Close connection
   connection.close()
-  println("\n✅ Test completed successfully!")
+  println("\n✅ All tests completed successfully!")
 }
 
 // To run this example:


### PR DESCRIPTION
## Summary

- Add `ParameterBinder` instances for `Float`, `java.sql.Date`, `BigDecimal`, `Array[Byte]` (BLOB), `java.time.LocalDate`, `java.time.LocalDateTime`, and `java.time.OffsetDateTime` — covering the full set of common DuckDB column types
- Extend `BatchBinder` to support **5- and 6-element tuples** (previously capped at 4)
- Add corresponding `setFloat`, `setDate`, `setBigDecimal`, `setBytes`, `setTimestamp`, `setObject` setters on `DuckDBPreparedStatement` and matching `getFloat`, `getDate`, `getBigDecimal`, `getBytes`, `getTimestamp`, `getObject` getters on `DuckDBResultSet`
- Document the complete type matrix in the getting-started guide, including a worked example using all types in a single prepared statement and batch insert

## Test plan

- [ ] `mill __.test` passes for all Scala versions (3.3.6 and 3.8.2)
- [ ] New batch tests: `float/date/BigDecimal/bytes`, `java.time binders`, `Timestamp/UUID` round-trips
- [ ] New prepared-statement tests: `timestamp`, `uuid`, `float`, `date`, `BigDecimal`, `bytes`, `LocalDate`, `LocalDateTime`
- [ ] Doc example code compiles via snippet compiler (`mill 'duck4s[3.8.2].docJar'`)